### PR TITLE
Avoid sourcing the plan when running in a CI env

### DIFF
--- a/bin/studio-common
+++ b/bin/studio-common
@@ -18,8 +18,11 @@
 #
 
 # Source the plan.sh and default.toml files (if they exist)
-source /src/habitat/plan.sh
-export TOML_FILE=/src/habitat/default.toml
+# Avoid loading these files when running in a CI environment.
+if [[ -z "$CI" ]]; then
+  source /src/habitat/plan.sh
+  export TOML_FILE=/src/habitat/default.toml
+fi
 
 # The folder where all the documentation is stored
 [[ ! -d /tmp/docs ]] && mkdir /tmp/docs


### PR DESCRIPTION
Otherwise we will see the following error:
```
/hab/pkgs/chef/ci-studio-common/0.1.6/20171003194552/bin/studio-common: line 21: /src/habitat/plan.sh: No such file or directory
```

![tenor-215603031](https://user-images.githubusercontent.com/5712253/31294632-a9f3c514-aaa9-11e7-9adb-eb782d6fb4fd.gif)
