### PR TITLE
Add bldr.toml that disables auto builds

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -1,0 +1,3 @@
+# Disable auto-builds
+[ci-studio-common]
+paths = []


### PR DESCRIPTION
This will set us up for a near future when we'll leverage the Habitat Build Service. Rather than building on every push to master, we'll rely on Expeditor to trigger the builds as part of it's action set. 

Signed-off-by: Tom Duffield <tom@chef.io>