### PR TITLE
Remove unnecessary release from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # Changelog
 
 <!-- latest_release 0.1.20 -->
-## [0.1.20](https://github.com/chef/ci-studio-common/tree/0.1.20) (2017-10-11)
-
-#### Merged Pull Requests
-- Empty change to test Expeditor [#32](https://github.com/chef/ci-studio-common/pull/32) ([tduffield](https://github.com/tduffield))
 <!-- latest_release -->
 
 ## [0.1.19](https://github.com/chef/ci-studio-common/tree/0.1.19) (2017-10-10)


### PR DESCRIPTION
I merged a test change to test Expeditor, but I forgot to skip the changelog update.

Signed-off-by: Tom Duffield <tom@chef.io>