### PR TITLE
Add wait_for_ok_response

### DIFF
--- a/dot-studio/svc_coord
+++ b/dot-studio/svc_coord
@@ -69,3 +69,24 @@ function wait_for_port_to_listen() {
     [[ "$2" != "silent" ]] && echo " => Waiting for port $1 to be listening"
   done
 }
+
+document "wait_for_ok_response" <<DOC
+  Wait for the provided URL to response with status code (200)
+
+  @(arg:1) URL to curl
+
+  Example: Wait for www.google.com to return Ok
+  ---------------------------------------------
+  wait_for_ok_response www.google.com
+DOC
+function wait_for_ok_response() {
+  [[ "$1" == "" ]] && echo "Missing url argument; try 'describe wait_for_ok_response'" && return 1;
+  # Customize code?
+  code=200;
+  install_if_missing core/curl curl
+  while : ; do
+    response=$(curl --write-out %{http_code} --silent --output /dev/null $1)
+    [[ $response -eq $code ]] && break || sleep 1
+    echo " => Waiting for '$1' to response OK ($code). [Got:$response]"
+  done
+}


### PR DESCRIPTION
Wait until the provided URL response with Status Code: 200

Example:
```
wait_for_ok_response localhost:1234/version
=> Waiting for 'localhost:2192/version' to response OK (200). [Got:404]
=> Waiting for 'localhost:2192/version' to response OK (200). [Got:404]
=> Waiting for 'localhost:2192/version' to response OK (200). [Got:404]
```

Signed-off-by: Salim Afiune <afiune@chef.io>