### PR TITLE
Check if /src/.studio/ is not empty

### DIFF
--- a/bin/studio-common
+++ b/bin/studio-common
@@ -18,14 +18,14 @@
 #
 
 # This value is automatically updated by Expeditor to reflect .hab-version
-export SUPPORTED_HAB_VERSION="0.36.0"
+export SUPPORTED_HAB_VERSION="0.36.0";
 
 # Ensure that the installed version of the hab toolchain is >= to the required version.
 #
 # Given the rapid development and release cadence of Habitat, we want to ensure that
 # developers are using a version of Habitat is is well tested against both this library
 # and the supporting automation (i.e. Expeditor builds).
-required_version="$SUPPORTED_HAB_VERSION"
+required_version="$SUPPORTED_HAB_VERSION";
 installed_version=$(hab -V | awk '{print $NF}' | cut -f1 -d/);
 
 MAJOR=$(echo "$installed_version"  | cut -f1 -d.);
@@ -51,16 +51,16 @@ if [[ $MAJOR -ne $R_MAJOR ]]; then
 fi;
 
 if $need_upgrade; then
-  echo "ERROR: Habitat needs to be upgraded to version '$SUPPORTED_HAB_VERSION'"
-  echo "       Exit the studio and run the command:"
-  echo "       => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION"
+  echo "ERROR: Habitat needs to be upgraded to version '$SUPPORTED_HAB_VERSION'";
+  echo "       Exit the studio and run the command:";
+  echo "       => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
   exit 1
 fi;
 
 if $is_newer; then
-  echo "WARNING: Version '$installed_version' of Habitat has not been fully tested for compatibility with ci-studio-common."
-  echo "         Please consider exiting the studio and running the following command to install the recommended version:"
-  echo "         => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION"
+  echo "WARNING: Version '$installed_version' of Habitat has not been fully tested for compatibility with ci-studio-common.";
+  echo "         Please consider exiting the studio and running the following command to install the recommended version:";
+  echo "         => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
 fi;
 
 # Assuming we have the correct version of Habitat installed, we can proceed.
@@ -155,13 +155,14 @@ do
 done
 
 # Source all the files available in the .studio directory of the /src directory
-if [ -d /src/.studio ]
+# Only if the '.studio/' directory exists and it is not empty
+if [ "$(ls -A /src/.studioo 2>/dev/null)" ]
 then
   for file in /src/.studio/*
   do
     source "$file"
   done
-  source_msg="$source_msg and your local .studio folder"
-fi
+  source_msg="$source_msg and your local .studio folder";
+fi;
 
-echo "$source_msg have been added. Run 'describe' for more information."
+echo "$source_msg have been added. Run 'describe' for more information.";


### PR DESCRIPTION
This change fixes a problem where if you have a `/src/.studio` directory but it is empty (no files in it) you will see this error:
```
bash: /src/.studio/*: No such file or directory
```

Signed-off-by: Salim Afiune <afiune@chef.io>