### PR TITLE
Adding wait_or_fail Functions

### DIFF
--- a/dot-studio/svc_coord
+++ b/dot-studio/svc_coord
@@ -51,14 +51,24 @@ function wait_for_svc_to_load() {
 }
 
 document "wait_for_port_to_listen" <<DOC
-  Wait for a port to be listening.
-
+  Wait for a port to be listening. If the port is not found in the set amount of time the function exits with 1
   @(arg:1) Port to wait for to be listening
-  @(arg:2) Wheter or not this process runs silently
+  @(arg:2) Number of seconds to wait to exit with 1. Default 60 seconds.
+  @(arg:3) Wheter or not this process runs silently
+
+  Example: Wait for a service to start listening on port 1234 for 1 minute
+  ---------------------------------------------
+  wait_or_fail_for_port_to_listen 1234 60
 DOC
 function wait_for_port_to_listen() {
   install_if_missing core/busybox-static netstat
+  SECOUNDS_WAITING=$2
+  if [ -z "$SECOUNDS_WAITING" ]
+  then
+    SECOUNDS_WAITING=100
+  fi
   
+  COUNTER=0
   while : ; do
     if netstat -an | grep "$1" | grep LISTEN >/dev/null 2>/dev/null
     then
@@ -66,27 +76,50 @@ function wait_for_port_to_listen() {
     else
       sleep 1
     fi
-    [[ "$2" != "silent" ]] && echo " => Waiting for port $1 to be listening"
+
+    if [ $COUNTER -ge $SECOUNDS_WAITING ]
+    then
+      echo " => Failed listening for port $1"
+      exit 1
+    fi
+    let COUNTER=COUNTER+1
+    [[ "$3" != "silent" ]] && echo " => Waiting for port $1 to be listening ($COUNTER of $SECOUNDS_WAITING)"
   done
 }
 
 document "wait_for_ok_response" <<DOC
-  Wait for the provided URL to response with status code (200)
+  Wait a set amount of time for the provided URL to response with status code (200). 
+  If the time expires then exit with 1
 
   @(arg:1) URL to curl
+  @(arg:2) Number of seconds to wait to exit with 1. Default 60 seconds
 
-  Example: Wait for www.google.com to return Ok
+  Example: Wait for www.google.com to return Ok for 1 minute
   ---------------------------------------------
-  wait_for_ok_response www.google.com
+  wait_or_fail_for_ok_response www.google.com 60
 DOC
 function wait_for_ok_response() {
   [[ "$1" == "" ]] && echo "Missing url argument; try 'describe wait_for_ok_response'" && return 1;
-  # Customize code?
+
+  SECOUNDS_WAITING=$2
+  if [ -z "$SECOUNDS_WAITING" ]
+  then
+    SECOUNDS_WAITING=60
+  fi
+
   code=200;
   install_if_missing core/curl curl
+  COUNTER=0
   while : ; do
+    if [ $COUNTER -ge $SECOUNDS_WAITING ]
+    then
+      echo " => Failed listening for port $1"
+      exit 1
+    fi
+    let COUNTER=COUNTER+1
+
     response=$(curl --write-out %{http_code} --silent --output /dev/null $1)
     [[ $response -eq $code ]] && break || sleep 1
-    echo " => Waiting for '$1' to response OK ($code). [Got:$response]"
+    echo " => Waiting for '$1' to response OK ($code). [Got:$response] ($COUNTER of $SECOUNDS_WAITING)"
   done
 }

--- a/dot-studio/svc_coord
+++ b/dot-studio/svc_coord
@@ -51,7 +51,29 @@ function wait_for_svc_to_load() {
 }
 
 document "wait_for_port_to_listen" <<DOC
+  Wait for a port to be listening.
+
+  @(arg:1) Port to wait for to be listening
+  @(arg:2) Wheter or not this process runs silently
+DOC
+function wait_for_port_to_listen() {
+  install_if_missing core/busybox-static netstat
+  echo " => deprecated use wait_or_fail_for_port_to_listen"
+
+  while : ; do
+    if netstat -an | grep "$1" | grep LISTEN >/dev/null 2>/dev/null
+    then
+      break
+    else
+      sleep 1
+    fi
+    [[ "$2" != "silent" ]] && echo " => Waiting for port $1 to be listening"
+  done
+}
+
+document "wait_or_fail_for_port_to_listen" <<DOC
   Wait for a port to be listening. If the port is not found in the set amount of time the function exits with 1
+  
   @(arg:1) Port to wait for to be listening
   @(arg:2) Number of seconds to wait to exit with 1. Default 60 seconds.
   @(arg:3) Wheter or not this process runs silently
@@ -59,16 +81,16 @@ document "wait_for_port_to_listen" <<DOC
   Example: Wait for a service to start listening on port 1234 for 1 minute
   ---------------------------------------------
   wait_or_fail_for_port_to_listen 1234 60
+
+  Example: Wait for a service to start listening on port 1234 for 10 seconds
+  ---------------------------------------------
+  wait_or_fail_for_port_to_listen 1234 10
 DOC
-function wait_for_port_to_listen() {
+function wait_or_fail_for_port_to_listen() {
   install_if_missing core/busybox-static netstat
-  SECOUNDS_WAITING=$2
-  if [ -z "$SECOUNDS_WAITING" ]
-  then
-    SECOUNDS_WAITING=100
-  fi
+  local SECONDS_WAITING=${2:-60}
   
-  COUNTER=0
+  local COUNTER=0
   while : ; do
     if netstat -an | grep "$1" | grep LISTEN >/dev/null 2>/dev/null
     then
@@ -77,13 +99,13 @@ function wait_for_port_to_listen() {
       sleep 1
     fi
 
-    if [ $COUNTER -ge $SECOUNDS_WAITING ]
+    if [ $COUNTER -ge $SECONDS_WAITING ]
     then
       echo " => Failed listening for port $1"
       exit 1
     fi
     let COUNTER=COUNTER+1
-    [[ "$3" != "silent" ]] && echo " => Waiting for port $1 to be listening ($COUNTER of $SECOUNDS_WAITING)"
+    [[ "$3" != "silent" ]] && echo " => Waiting for port $1 to be listening ($COUNTER of $SECONDS_WAITING)"
   done
 }
 
@@ -97,29 +119,29 @@ document "wait_for_ok_response" <<DOC
   Example: Wait for www.google.com to return Ok for 1 minute
   ---------------------------------------------
   wait_or_fail_for_ok_response www.google.com 60
+
+  Example: Wait for www.google.com to return Ok for 10 seconds
+  ---------------------------------------------
+  wait_or_fail_for_ok_response www.google.com 10
 DOC
 function wait_for_ok_response() {
   [[ "$1" == "" ]] && echo "Missing url argument; try 'describe wait_for_ok_response'" && return 1;
 
-  SECOUNDS_WAITING=$2
-  if [ -z "$SECOUNDS_WAITING" ]
-  then
-    SECOUNDS_WAITING=60
-  fi
+  local SECONDS_WAITING=${2:-60}
 
   code=200;
   install_if_missing core/curl curl
-  COUNTER=0
+  local COUNTER=0
   while : ; do
-    if [ $COUNTER -ge $SECOUNDS_WAITING ]
+    if [ $COUNTER -ge $SECONDS_WAITING ]
     then
       echo " => Failed listening for port $1"
       exit 1
     fi
     let COUNTER=COUNTER+1
 
-    response=$(curl --write-out %{http_code} --silent --output /dev/null $1)
+    local response=$(curl --write-out %{http_code} --silent --output /dev/null $1)
     [[ $response -eq $code ]] && break || sleep 1
-    echo " => Waiting for '$1' to response OK ($code). [Got:$response] ($COUNTER of $SECOUNDS_WAITING)"
+    echo " => Waiting for '$1' to response OK ($code). [Got:$response] ($COUNTER of $SECONDS_WAITING)"
   done
 }


### PR DESCRIPTION
Adding wait_or_fail functions to exit out of tests if the service never
starts. We are finding that when some services do not start correctly
the wait_for methods are never ending. These new functions will allow
the wait to fail after a set amount of time.

<img width="686" alt="screen shot 2017-10-16 at 4 50 18 pm" src="https://user-images.githubusercontent.com/1679247/31640467-893a4ed2-b293-11e7-908f-168acd341122.png">

Signed-off-by: Lance Finfrock <lfinfrock@chef.io>