### PR TITLE
[BUG-FIX] Correct arguments for in_studio func

### DIFF
--- a/bin/hab-verify
+++ b/bin/hab-verify
@@ -33,14 +33,40 @@ ENVIRONMENT VARIABLES:
 DOC
 }
 
+# in_studio
+#
+# This function will run the provided command in the context
+# of a hab-studio, it will first make sure it has the sig-key
+# locally, if not it will automatically download it.
+#
+# This function sources your '.studiorc' first (since this functionality
+# was removed from the core of habitat) and then runs the command.
+#
+# @(arg:1) The command to execute inside a hab-studio
+#
+# Example: Run a custom function called 'integration' inside a hab-studio
+# -----------------------------------------------------------------------
+# in_studio integration
+#
 function in_studio() {
   origin="${HAB_ORIGIN:-chef}"
   export HAB_ORIGIN="$origin"
 
+  # We need to use $1 since we are calling the function as:
+  #
+  # in_studio TASK
+  #
+  # and it because its first parameter, not the global parameter of this script
+  if [[ -z "$1" ]]; then
+    echo "${0##*/}: Missing command to run in the context of a hab-studio"
+    echo "Try '${0##*/} --help' for more information."
+    exit 2
+  fi;
+
   hab-origin download-sig-key "$origin"
 
   # New version of Habitat doesn't source the .studiorc
-  cmd="source .studiorc;$2"
+  cmd="source .studiorc;$1"
 
   eval "hab studio $STUDIO_OPTS run \"$cmd\""
 }


### PR DESCRIPTION
This PR fixes the problem where the `hab-verify in-studio CMD` command won't run any command inside the studio since we moved its functionality into a function called `in_studio` and now we are passing the command to run as a sub-parameter to that function. Now we are using the right parameter (first argument`$1`) and also verifying that it is not empty.

![tenor-173723713](https://user-images.githubusercontent.com/5712253/32463498-09144a7c-c30b-11e7-9a0b-13e2af9566c7.gif)

Also put some extra comments explaining what's going on. 

Signed-off-by: Salim Afiune <afiune@chef.io>