### PR TITLE
Avoid running go env $GOPATH from docs

### DIFF
--- a/dot-studio/protobuf
+++ b/dot-studio/protobuf
@@ -26,7 +26,7 @@ document "compile_go_protobuf" <<DOC
   ------------------------------------------------------------------
   #!/bin/bash
   set -x
-  GOPATH=$(go env GOPATH)
+  GOPATH=\$(go env GOPATH)
 
   protoc -I. \\
     -I$GOPATH/src \\


### PR DESCRIPTION
I was seeing this error every time we enter our studios:
```
+++ source /hab/pkgs/chef/ci-studio-common/0.1.43/20171115201623/dot-studio/protobuf
++++ document compile_go_protobuf
+++++ go env GOPATH
bash: go: command not found
```

This is the fix! :)