### PR TITLE
Static Linking Warning Fix

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -158,6 +158,11 @@ function go_build() {
   # Add static linked flags if needed
   go_cmd="$go_cmd $(go_static_linked_flags)";
 
+  if [[ $GO_STATIC_BIN == true ]]; then
+    install_if_missing core/musl musl-gcc;
+    export CC=$(hab pkg path core/musl)/bin/musl-gcc;
+  fi
+
   pushd $scaffolding_go_pkg_path >/dev/null
     if [[ $GO_FAST != true ]]; then
       [[ $RUN_GO_GENERATE == true ]] && echo "=> Executing Go generate" && go generate


### PR DESCRIPTION
Without this change when running a 'go build' the below warning would be
displayed

```
/tmp/go-link-561868995/000000.o: In function
`_cgo_b0c710f30cfd_C2func_getaddrinfo':
/tmp/go-build/net/_obj/cgo-gcc-prolog:46: warning: Using 'getaddrinfo'
in statically linked applications requires at runtime the shared
libraries from the glibc version used for linking
```

Even though the two lines added to the go_build function are being called in the
'go_static_linked_flags' function, the 'CC' variable is not being
exported publicly because of the the way it is being called.

resolves: https://github.com/chef/converge-service/issues/253
Signed-off-by: Lance Finfrock <lfinfrock@chef.io>