### PR TITLE
Use 'pwd' instead of Travis build directory to determine location

### DIFF
--- a/bin/run-if-changed
+++ b/bin/run-if-changed
@@ -54,7 +54,8 @@ function enforce_requirements() {
 }
 
 function run_if_changed() {
-  # If unspecified, set the workdir to the current working directoy
+  # If unspecified, set the workdir to the current working directory
+  CWD=$(pwd)
   WORKDIR=${WORKDIR:-"./"}
   GLOBS=${GLOBS:-"$WORKDIR/*"}
 
@@ -76,7 +77,9 @@ function run_if_changed() {
     echo "No files were modified in '${WORKDIR}': exiting."
     exit 0
   else
-    cd "$TRAVIS_BUILD_DIR/$WORKDIR" || exit 1
+    echo "cd $CWD/$WORKDIR"
+    cd "$CWD/$WORKDIR" || exit 1
+    echo "$@"
     eval "$@"
   fi
 }


### PR DESCRIPTION
The go language in Travis actually symlinks code into the GOPATH. By
cd-ing out of the GOPATH, we could be causing unknown behavior. This
change just determines where we are starting out. This has the added
benefit of expanding support outside of Travis by no longer depending
on Travis variables.

Signed-off-by: Tom Duffield <tom@chef.io>