### PR TITLE
Fix typos in aliases

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -315,7 +315,7 @@ function go_debug_attach_running_service() {
   fi
   go_debug_attach_to_pid $pid
 }
-add_alias "go_debug_attach_running_service " "gdas"
+add_alias "go_debug_attach_running_service" "gdas"
 
 
 # Connect to the provided PID process (Must be a Go Applicaiton)
@@ -344,7 +344,7 @@ function go_debug_attach_to_pid() {
     eval $go_cmd
   popd >/dev/null
 }
-add_alias "go_debug_attach_to_pid " "gdatt"
+add_alias "go_debug_attach_to_pid" "gdatp"
 
 # Helper function to search for the PID of the service
 function grep_service_pid() {


### PR DESCRIPTION
I kept seeing this in our studios:
```
ALIASES:
  co     Alias for: compile_go_protobuf
  de     Alias for: dep_ensure
  egw    Alias for: enter_go_workspace
  gb     Alias for: go_build
cat: /tmp/aliases/go_debug_attach_running_service: No such file or directory
         Alias for: go_debug_attach_running_service
cat: /tmp/aliases/go_debug_attach_to_pid: No such file or directory
         Alias for: go_debug_attach_to_pid
  gdm    Alias for: go_debug_mode
  gds    Alias for: go_debug_server
  sl     Alias for: sup-log
  sr     Alias for: sup-run
  st     Alias for: sup-term
```
Signed-off-by: Salim Afiune <afiune@chef.io>