### PR TITLE
golang: run `dep ensure -vendor-only`

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -8,7 +8,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -201,7 +201,7 @@ document "dep_ensure" <<DOC
   development cycles.
 DOC
 function dep_ensure() {
-  local go_cmd="dep ensure";
+  local go_cmd="dep ensure -vendor-only";
   if [[ $GO_FAST != true ]]; then
     echo "(help) You can always set 'GO_FAST=true' to go faster!";
     install_go_tool github.com/golang/dep/cmd/dep;


### PR DESCRIPTION
this ensures that when we build our tooling in CI that we
only fetch deps that are specified in the lockfile and do
not update libraries that haven't been explicitly checked
in during development.

Signed-off-by: Stephen Delano <stephen@chef.io>