### PR TITLE
Fix hab-origin with multiple pub-keys & Enable installation from a dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ before_install:
   - export PATH="$PATH:$HOME/ci-studio-common/bin:$HOME/tools/bin"
 ```
 
+If you would like to make an installation from a branch that is under
+development, you can add `-s -- BRANCH_NAME` at the end of the `curl` command.
+```
+curl https://raw.githubusercontent.com/chef/ci-studio-common/master/install.sh | bash -s -- BRANCH_NAME
+```
+
 ### Environment Variables
 
 Various helpers and other operations assume the presence of certain environment variables. Here are the list of environment variables that should be present:

--- a/bin/hab-origin
+++ b/bin/hab-origin
@@ -50,7 +50,8 @@ function download_sig_key() {
   hab origin key download "$origin"
 
   # Extract the name of the key+revision from the public key
-  key_with_revision=$(find "$HOME/.hab/cache/keys" -name "$origin-20*.pub" -exec basename {} \; | cut -d'.' -f1)
+  # (@afiune) The last entry is the active key
+  key_with_revision=$(find "$HOME/.hab/cache/keys" -name "$origin-20*.pub" -exec basename {} \; | cut -d'.' -f1 | tail -1)
 
   if [ ! -f "$HOME/.hab/cache/keys/${key_with_revision}.sig.key" ]
   then

--- a/install.sh
+++ b/install.sh
@@ -16,14 +16,21 @@
 # limitations under the License.
 #
 
+# The branch we will install the source code from
+#
+# Example: Install from the 'foo' branch
+# => curl https://raw.githubusercontent.com/chef/ci-studio-common/master/install.sh | bash -s -- foo
+branch=${1-master}
+
 if [ -d $HOME/ci-studio-common ]
 then
   rm -rf $HOME/ci-studio-common
 fi
 
 pushd /tmp
-  curl -sLo ci-studio-common.zip https://github.com/chef/ci-studio-common/archive/master.zip
+  curl -sLo ci-studio-common.zip https://github.com/chef/ci-studio-common/archive/${branch}.zip
   unzip ci-studio-common.zip
   rm -f ci-studio-common.zip || true
-  mv ci-studio-common-master "$HOME/ci-studio-common"
+  ci_dir=$(echo "ci-studio-common-${branch}" | tr '/' '-')
+  mv $ci_dir "$HOME/ci-studio-common"
 popd


### PR DESCRIPTION
This PR is a **fix and a new feature.**

**FIX**: When an origin has more than one public key listed we need to use the last entry since that is the active one. This is important to check with citadel the right `key_revision`.

**FEATURE**: I was trying to test this code living in a branch without merging to master and I wondered: How can I do this? Well, with the commit https://github.com/chef/ci-studio-common/pull/78/commits/f1e59f704884baf6aefa4ba566e0369171edc090 you can now run the following command to install `ci-studio-common` from this branch: (as an example)
```
curl https://raw.githubusercontent.com/chef/ci-studio-common/master/install.sh | bash -s -- afiune/fix-hab-origin
```

Signed-off-by: Salim Afiune <afiune@chef.io>