### PR TITLE
dep_ensure runs only when vendor/ is missing

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -147,13 +147,9 @@ document "go_build" <<DOC
   2) To run 'dep ensure' set:
   => export RUN_GO_DEP=true
 
-  Example 2 :: Build the default binary without deps and/or 'go generate'.
+  Example 2 :: Build and place the binary file in a specific location.
   ------------------------------------------------------------------------
-  GO_FAST=true go_build
-
-  Example 3 :: Build and place the binary file in a specific location.
-  ------------------------------------------------------------------------
-  GO_FAST=true go_build main.go /src/bin/main
+  go_build main.go /src/bin/main
 DOC
 function go_build() {
   [[ "$1" == "" ]] && go_main="cmd/${pkg_name}/${pkg_name}.go" || go_main=$1
@@ -176,10 +172,8 @@ function go_build() {
   fi
 
   pushd $scaffolding_go_pkg_path >/dev/null
-    if [[ $GO_FAST != true ]]; then
-      [[ $RUN_GO_GENERATE == true ]] && echo "=> Executing Go generate" && go generate
-      [[ $RUN_GO_DEP == true ]] && dep_ensure
-    fi;
+    [[ $RUN_GO_GENERATE == true ]] && echo "=> Executing Go generate" && go generate
+    [[ $RUN_GO_DEP == true ]] && dep_ensure
     echo "=> Executing Go build"
     eval "$go_cmd $go_main"
     # Save the exit code to return it latter
@@ -192,25 +186,22 @@ function go_build() {
 add_alias "go_build" "gb"
 
 document "dep_ensure" <<DOC
-  Runs the go dependency solver. (a.k.a. dep ensure)
+  Runs the go dependency solver if vendor/ is missing.
 
   This helper will ensure your Go workspace is configured and that
   you have the dep tool installed.
-
-  Set 'GO_FAST=true' env variable to skip this task only for faster
-  development cycles.
 DOC
 function dep_ensure() {
   local go_cmd="dep ensure -vendor-only";
-  if [[ $GO_FAST != true ]]; then
-    echo "(help) You can always set 'GO_FAST=true' to go faster!";
-    install_go_tool github.com/golang/dep/cmd/dep;
-    echo "=> Executing Go dependency solver ($go_cmd)";
-    pushd $scaffolding_go_pkg_path >/dev/null;
+  pushd $scaffolding_go_pkg_path >/dev/null;
+    # Run dep ensure only if vendor/ directory is missing
+    if [ ! -d vendor ]; then
+      install_go_tool github.com/golang/dep/cmd/dep;
+      echo "=> Executing Go dependency solver ($go_cmd)";
       eval $go_cmd;
       local EXIT_CODE=$?;
-    popd >/dev/null;
-  fi;
+    fi;
+  popd >/dev/null;
   return $EXIT_CODE;
 }
 add_alias "dep_ensure" "de"


### PR DESCRIPTION
This commit is updating the `dep_ensure` helper to only run when the
vendor/ directory is missing. Think about this helper as a safety hook
that, when you call it, it will ensure you have your dependencies, but
if you already have them, then it won't modify them. If you need to
actually update your Go dependencies you have to run `dep ensure`
manually.

### NOTE: We are eliminating the use of GO_FAST

Tested this locally, if we do NOT have a `vendor/` dir:
```
=> Configuring Go Workspace. [please wait]
=> Available scaffolding variables:
$scaffolding_go_gopath        - /hab/cache/src/go
$scaffolding_go_workspace_src - /hab/cache/src/go/src
$scaffolding_go_pkg_path      - /hab/cache/src/go/src/github.com/chef/a2
=> Installing Go Tool 'dep'
=> Executing Go dependency solver (dep ensure -vendor-only)
=> Executing Go build
=> Reloading config-mgmt-service binary
Run 'go_update_component config-mgmt-service' to update config-mgmt-service binary.
```

With `vendor/` dir, it won't execute `dep ensure`:
```
=> Configuring Go Workspace. [please wait]
=> Available scaffolding variables:
$scaffolding_go_gopath        - /hab/cache/src/go
$scaffolding_go_workspace_src - /hab/cache/src/go/src
$scaffolding_go_pkg_path      - /hab/cache/src/go/src/github.com/chef/a2
=> Executing Go build
=> Reloading config-mgmt-service binary
Run 'go_update_component config-mgmt-service' to update config-mgmt-service binary.
```
Signed-off-by: Salim Afiune <afiune@chef.io>