### PR TITLE
Update version help to include `hab studio rm`

### DIFF
--- a/bin/studio-common
+++ b/bin/studio-common
@@ -66,7 +66,7 @@ if $need_upgrade; then
   echo "ERROR: Habitat needs to be upgraded to version '$SUPPORTED_HAB_VERSION'";
   echo "       Run:";
   echo "       => hab studio rm";
-  echo "       to remove the sudio, and then";
+  echo "       to remove the studio, and then";
   echo "       => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
   exit 1
 fi;
@@ -75,7 +75,7 @@ if $is_newer; then
   echo "WARNING: Version '$installed_version' of Habitat has not been fully tested for compatibility with ci-studio-common.";
   echo "         Please consider exiting the sudio, running:";
   echo "         => hab studio rm";
-  echo "         to remove the sudio, and then";
+  echo "         to remove the studio, and then";
   echo "         => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
 fi;
 

--- a/bin/studio-common
+++ b/bin/studio-common
@@ -73,7 +73,7 @@ fi;
 
 if $is_newer; then
   echo "WARNING: Version '$installed_version' of Habitat has not been fully tested for compatibility with ci-studio-common.";
-  echo "         Please consider exiting the sudio, running:";
+  echo "         Please consider exiting the studio, running:";
   echo "         => hab studio rm";
   echo "         to remove the studio, and then";
   echo "         => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";

--- a/bin/studio-common
+++ b/bin/studio-common
@@ -64,14 +64,18 @@ fi;
 
 if $need_upgrade; then
   echo "ERROR: Habitat needs to be upgraded to version '$SUPPORTED_HAB_VERSION'";
-  echo "       Exit the studio and run the command:";
+  echo "       Run:";
+  echo "       => hab hab studio rm";
+  echo "       to remove the sudio, and then";
   echo "       => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
   exit 1
 fi;
 
 if $is_newer; then
   echo "WARNING: Version '$installed_version' of Habitat has not been fully tested for compatibility with ci-studio-common.";
-  echo "         Please consider exiting the studio and running the following command to install the recommended version:";
+  echo "         Please consider exiting the sudio, running:";
+  echo "         => hab hab studio rm";
+  echo "         to remove the sudio, and then";
   echo "         => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
 fi;
 

--- a/bin/studio-common
+++ b/bin/studio-common
@@ -65,7 +65,7 @@ fi;
 if $need_upgrade; then
   echo "ERROR: Habitat needs to be upgraded to version '$SUPPORTED_HAB_VERSION'";
   echo "       Run:";
-  echo "       => hab hab studio rm";
+  echo "       => hab studio rm";
   echo "       to remove the sudio, and then";
   echo "       => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
   exit 1
@@ -74,7 +74,7 @@ fi;
 if $is_newer; then
   echo "WARNING: Version '$installed_version' of Habitat has not been fully tested for compatibility with ci-studio-common.";
   echo "         Please consider exiting the sudio, running:";
-  echo "         => hab hab studio rm";
+  echo "         => hab studio rm";
   echo "         to remove the sudio, and then";
   echo "         => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v $SUPPORTED_HAB_VERSION";
 fi;


### PR DESCRIPTION
By the time the version check occurs, a version of `hab` other than `required_version` has been installed. Installing the correct version on the system won't change what's installed in the studio, so it needs to be removed.