### PR TITLE
Allow for local development by sourcing dot-studio files with relative path

### DIFF
--- a/bin/studio-common
+++ b/bin/studio-common
@@ -165,7 +165,14 @@ fi
 
 source_msg="Helpers from ci-studio-common"
 
-for file in $(hab pkg path "chef/ci-studio-common")/dot-studio/*
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dot_studio_dir="$script_dir/../dot-studio"
+if ! [ -d "$dot_studio_dir" ]; then
+  echo "ERROR: Expected dot-studio directory at $(realpath "$dot_studio_dir")"
+  exit 1
+fi
+
+for file in $dot_studio_dir/*
 do
   source "$file"
 done


### PR DESCRIPTION
Instead of using `hab pkg path` to determine the path to the dot-studio
directory, find it relative to the location of the studio-common script. This
facilitates testing local changes to ci-studio-common without having to
upload and promote habitat packages.