### PR TITLE
Unset CC during protobuf compile

### DIFF
--- a/dot-studio/protobuf
+++ b/dot-studio/protobuf
@@ -37,6 +37,8 @@ document "compile_go_protobuf" <<DOC
 DOC
 function compile_go_protobuf() {
   proto_script="${1:-scripts/grpc.sh}"
+  OLD_CC=$CC
+  unset CC
 
   # Verify that the script exist ans it is an executable
   if [[ -x $proto_script ]]; then
@@ -71,8 +73,10 @@ function compile_go_protobuf() {
   else
     echo "ERROR: '$proto_script' doesn't exist or is not executable."
     echo "Try 'describe ${FUNCNAME[0]}'."
+    CC=$OLD_CC
     return 1
   fi
+
+  CC=$OLD_CC
 }
 add_alias "compile_go_protobuf" "co"
-


### PR DESCRIPTION
This is documentation via PR about a problem in the current studio
setup.  Because many of our builds use static linking, the A2 studio
sets GO_STATIC_BIN=true which ends up exporting CC as musc-gcc.

This breaks pretty much any go compiles that /isn't/ statically
linked.

I fixed this for deployment service by moving us to use static
linking, but others are still seeing it compiling protobufs because
some protobuf compiles require additional go compilations.

I think the *complete* fix is to make sure that variables like CC
aren't leaked into the environment and that any build scripts are set
up to modify their own environment as needed.

Signed-off-by: Steven Danna <steve@chef.io>