### PR TITLE
Don't use unbound variables

### DIFF
--- a/dot-studio/hab_toolchain
+++ b/dot-studio/hab_toolchain
@@ -68,8 +68,10 @@ DOC
 function install() {
   install_cmd="install"
 
-  if [[ "x$OPTS" != "x" ]]; then
-    install_cmd="$install_cmd $OPTS"
+  local install_cmd_opts=${OPTS:-""}
+
+  if [[ "x$install_cmd_opts" != "x" ]]; then
+    install_cmd="$install_cmd $install_cmd_opts"
   fi
 
   if [[ "x$1" == "x" ]]; then


### PR DESCRIPTION
We now set -u in a number of places so it isn't safe to refer to
unbound variables anywhere.

Signed-off-by: Steven Danna <steve@chef.io>