### PR TITLE
Don't set -eou pipefile in bin/studio-common

### DIFF
--- a/bin/studio-common
+++ b/bin/studio-common
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-set -eou pipefail
-
 # Error out if someone tries to execute this script, rather than sourcing it.
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   cat <<'DOC'


### PR DESCRIPTION
This file is sourced in the A2 dev environment. These options are
great for scripts but not appropriate for interactive shells.

Signed-off-by: Steven Danna <steve@chef.io>