### PR TITLE
install_if_missing, just do it quietly

### DIFF
--- a/dot-studio/hab_toolchain
+++ b/dot-studio/hab_toolchain
@@ -137,11 +137,9 @@ function install_if_missing() {
 
   # Install the package if it is not installed
   if [[ ! -d "/hab/pkgs/$1" ]]; then
-    install "$1"
-  else
-    echo "$(hab pkg path "$1") is already installed"
+    install "$1" > /dev/null
   fi
 
   # Ensure we are binlinking to the same version `hab pkg exec` would run
-  hab pkg binlink --force "$1" "$2"
+  hab pkg binlink --force "$1" "$2" > /dev/null
 }


### PR DESCRIPTION
There are many places in the A2 .studiorc and friends that we use
`install_if_missing` deep inside of functions and to wrap other
tools. We rely on `install_if_missing` to work silently, because
we rely on having the ability to parse the output of the tools that
it installs. We need to make `install_if_missing` quiet again.

This change landed in stable today and has caused multiple things
to break:

https://github.com/chef/ci-studio-common/commit/4aab13426154cb2afff21536d0973685caa83cfd

We've already shipped one fix to A2, but it looks like this is the
root cause so it's better to just make this silent like it's always
been than to play whack-a-mole for every place we use it.

Signed-off-by: Stephen Delano <stephen@chef.io>