### PR TITLE
Fix wait_for_success to wait for success and not failure

### DIFF
--- a/dot-studio/svc_coord
+++ b/dot-studio/svc_coord
@@ -36,7 +36,7 @@ function wait_for_success() {
   local SECONDS_WAITING=${TIMEOUT:-60}
   local COUNTER=0
 
-  while "$@" &> /dev/null; do
+  until "$@" &> /dev/null; do
     sleep 1
 
     echo " => Waiting for '$*' to succeed. ($COUNTER of $SECONDS_WAITING)"


### PR DESCRIPTION
```
[8][default:/src:0]# wait_for_success asdfasdf
 => Waiting for 'asdfasdf' to succeed. (0 of 60)
 => Waiting for 'asdfasdf' to succeed. (1 of 60)
 => Waiting for 'asdfasdf' to succeed. (2 of 60)
 => ERROR: Command 'asdfasdf' never succeeded in 3 seconds.
[18][default:/src:1]# echo $?
1
[9][default:/src:130]# wait_for_success ls
[13][default:/src:0]# echo $?
0
```