### PR TITLE
Ensure Hab packages are promoted to `dev`

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -6,6 +6,11 @@ slack:
 habitat_packages:
   - ci-studio-common
 
+promote:
+  channels:
+    - dev
+    - stable
+
 merge_actions:
   - built_in:bump_version:
       ignore_labels:


### PR DESCRIPTION
This config ensures we promte to `dev` after  we successfully build the Habitat package.

More details on this auto-promotion logic can be found at:
https://expeditor.chef.io/docs/integrations/habitat/

Signed-off-by: Seth Chisamore <schisamo@chef.io>