### PR TITLE
Update generate_netrc_config error message

### DIFF
--- a/dot-studio/studio_setup
+++ b/dot-studio/studio_setup
@@ -23,6 +23,10 @@ document "generate_netrc_config" <<DOC
   pattern is for projects to use the git+https protocol in conjuction with a
   .netrc file.
 
+  Requirements:
+  => Habitat 0.54.0 or greater installed
+  => Specify 'HAB_STUDIO_SECRET_GITHUB_TOKEN' in your shell environment (outside the studio)
+
   To learn more about .netrc files, you can check out the following documentation:
 
     https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
@@ -30,9 +34,9 @@ DOC
 function generate_netrc_config() {
   if [[ -z "$GITHUB_TOKEN" ]]; then
     echo -e "\\nError: Unable to configure ~/.netrc in the studio."
-    echo "Missing the environment variable: GITHUB_TOKEN"
-    echo -e "\\nVerify that you have a file called '.secrets' with the following export:"
-    echo "export GITHUB_TOKEN=[your-secret-token]"
+    echo "Missing the environment variable: HAB_STUDIO_SECRET_GITHUB_TOKEN"
+    echo -e "\\nVerify that you have this variable exported before entering the studio:"
+    echo "export HAB_STUDIO_SECRET_GITHUB_TOKEN=[your-secret-token]"
     exit 1
   else
     echo -e "machine github.com\\n  login $GITHUB_TOKEN" >> ~/.netrc


### PR DESCRIPTION
With the new version of habitat, we no longer use the `.secrets` pattern but instead we use the proper habitat way to share secrets through env variables, in our case we use `HAB_STUDIO_SECRET_GITHUB_TOKEN` that needs to be exported before entering the studio. 

This PR is updating the error message to give better instructions of what needs to happen to fix the problem.