### PR TITLE
Enforce correct permissions on netrc

### DIFF
--- a/dot-studio/studio_setup
+++ b/dot-studio/studio_setup
@@ -40,6 +40,7 @@ function generate_netrc_config() {
     exit 1
   else
     echo -e "machine github.com\\n  login $GITHUB_TOKEN" >> ~/.netrc
+    chmod 0600 ~/.netrc
   fi
 }
 


### PR DESCRIPTION
Some software, such as libraries used by oc-chef-pedant will fail if the file is not `0600`