### PR TITLE
Install curl command before using it

### DIFF
--- a/bin/studio-common
+++ b/bin/studio-common
@@ -28,9 +28,8 @@ DOC
   exit 1
 fi
 
-# Install curl silently (we can't use `install_if_missing` because it is not yet loaded)
-hab pkg install -b core/curl >/dev/null
-SUPPORTED_HAB_VERSION=$(curl -sL https://raw.githubusercontent.com/chef/ci-studio-common/master/.hab-version)
+CURL="$(hab pkg path core/curl)/bin/curl"
+SUPPORTED_HAB_VERSION=$($CURL -sL https://raw.githubusercontent.com/chef/ci-studio-common/master/.hab-version)
 export SUPPORTED_HAB_VERSION
 
 # Ensure that the installed version of the hab toolchain is >= to the required version.

--- a/bin/studio-common
+++ b/bin/studio-common
@@ -28,6 +28,8 @@ DOC
   exit 1
 fi
 
+# Install curl silently (we can't use `install_if_missing` because it is not yet loaded)
+hab pkg install -b core/curl >/dev/null
 SUPPORTED_HAB_VERSION=$(curl -sL https://raw.githubusercontent.com/chef/ci-studio-common/master/.hab-version)
 export SUPPORTED_HAB_VERSION
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -4,6 +4,7 @@ pkg_maintainer="Engineering Services <eng-services@chef.io>"
 pkg_description="Shared helpers for use inside CIs (like Travis) and a Habitat Studio"
 pkg_license=('Apache-2.0')
 pkg_upstream_url=https://github.com/chef/ci-studio-common
+pkg_deps=core/curl
 pkg_bin_dirs=(bin)
 
 pkg_version() {


### PR DESCRIPTION
This PR fixes the following error message when you enter the studio and source ci-studio-common:
```
✓ Installed chef/ci-studio-common/1.1.19/20180911215228
★ Install of chef/ci-studio-common/1.1.19/20180911215228 complete with 1 new packages installed.
/hab/pkgs/chef/ci-studio-common/1.1.19/20180911215228/bin/studio-common: line 31: curl: command not found
WARNING: Version '0.59.0' of Habitat has not been fully tested for compatibility with ci-studio-common.
    Please consider exiting the studio, running:
    => hab studio rm
    to remove the studio, and then
    => curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -v
Helpers from ci-studio-common and your local .studio folder have been added. Run 'describe' for more information.
```