### PR TITLE
Adds ability to install go tools NOT from vendor/

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -95,14 +95,14 @@ document "install_go_tool" <<DOC
   ---------------------------------------------------------------------------------
   GO_STATIC_BIN=true install_go_tool github.com/golang/dep/cmd/dep
 
-  Example 2 :: Install a go tool that you in your local vendor/ directory
+  Example 2 :: Install a number of go tools from your vendor/ directory
   --------------------------------------------------------------------------
   local proto_go_tools=(
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
     github.com/golang/protobuf/protoc-gen-go
   )
-  GO_TOOL_METHOD="install" install_go_tool \${proto_go_tools[@]}
+  GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool "\${proto_go_tools[@]}"
 DOC
 function install_go_tool() {
   setup_go_workspace
@@ -120,9 +120,9 @@ function install_go_tool() {
   ( cd "$GOPATH" || exit
     for tool in "$@"; do
       go_tool=$(basename "$tool")
-      if [[ ! -f "${GOPATH}/bin/${go_tool}" ]]; then
+      if [ ! -f "${GOPATH}/bin/${go_tool}" ]; then
         echo "=> Installing Go Tool '${go_tool}'"
-        if [[ "$GO_TOOL_METHOD" == "install" ]]; then
+        if [ "$GO_TOOL_VENDOR" == true ]; then
           go_import_path=${scaffolding_go_import_path:-$scaffolding_go_base_path/$pkg_name}
           eval "$go_cmd $go_import_path/vendor/$tool"
         else

--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -87,8 +87,8 @@ document "install_go_tool" <<DOC
 
   @(arg:*) The array of packages you wish to install.
 
-  The default behavior is to install go tools with 'go get -u' but you can override
-  this by specifying the \$GO_TOOL_METHOD="install" so that it uses 'go install -v'
+  The default behavior is to install go tools with 'go install -v' but you can
+  override this by specifying the \$GO_TOOL_METHOD="get" so that it uses 'go get -u'
   instead, be aware that you have to have a vendor/ directory with the tools.
 
   Example 1 :: Install the listed go tool generating a static linked binary
@@ -102,13 +102,17 @@ document "install_go_tool" <<DOC
     github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
     github.com/golang/protobuf/protoc-gen-go
   )
-  GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool "\${proto_go_tools[@]}"
+  GO_TOOL_VENDOR=true install_go_tool "\${proto_go_tools[@]}"
+
+  Example 3 :: Install a go tool from the internet. (No version control)
+  --------------------------------------------------------------------------
+  GO_TOOL_METHOD="get" install_go_tool "\${proto_go_tools[@]}"
 DOC
 function install_go_tool() {
   setup_go_workspace
-  local go_cmd="go get -u"
-  if [[ "$GO_TOOL_METHOD" == "install" ]]; then
-   go_cmd="go install -v"
+  local go_cmd="go install -v"
+  if [[ "$GO_TOOL_METHOD" == "get" ]]; then
+    go_cmd="go get -u"
   fi
 
   # Add static linked flags if needed

--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -124,7 +124,7 @@ function install_go_tool() {
   ( cd "$GOPATH" || exit
     for tool in "$@"; do
       go_tool=$(basename "$tool")
-      if [ ! -f "${GOPATH}/bin/${go_tool}" ]; then
+      if [[ ! -f "${GOPATH}/bin/${go_tool}" ]]; then
         echo "=> Installing Go Tool '${go_tool}'"
         if [ "$GO_TOOL_VENDOR" == true ]; then
           go_import_path=${scaffolding_go_import_path:-$scaffolding_go_base_path/$pkg_name}

--- a/dot-studio/protobuf
+++ b/dot-studio/protobuf
@@ -44,7 +44,7 @@ function compile_go_protobuf() {
   # Verify that the script exist ans it is an executable
   if [[ -x $proto_script ]]; then
     install_if_missing core/protobuf-cpp protoc
-    GO_TOOL_METHOD="install" install_go_tool github.com/golang/protobuf/protoc-gen-go
+    GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool github.com/golang/protobuf/protoc-gen-go
 
     # Install grpc-gateway
     # only_if the script has an entry like: '--grpc-gateway_out'
@@ -54,11 +54,7 @@ function compile_go_protobuf() {
         github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
       )
 
-      # BUG: protoc-gen-grpc-gateway depends on github.com/golang/glog
-      #      so we have to install it first via 'go get'
-      install_go_tool github.com/golang/glog >/dev/null
-      # shellcheck disable=SC2068
-      GO_TOOL_METHOD="install" install_go_tool ${grpc_gateway_proto_tools[@]}
+      GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool "${grpc_gateway_proto_tools[@]}"
     fi
 
     # Install protoc-gen-lint from the internet instead of

--- a/dot-studio/protobuf
+++ b/dot-studio/protobuf
@@ -44,7 +44,7 @@ function compile_go_protobuf() {
   # Verify that the script exist ans it is an executable
   if [[ -x $proto_script ]]; then
     install_if_missing core/protobuf-cpp protoc
-    GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool github.com/golang/protobuf/protoc-gen-go
+    GO_TOOL_VENDOR=true install_go_tool github.com/golang/protobuf/protoc-gen-go
 
     # Install grpc-gateway
     # only_if the script has an entry like: '--grpc-gateway_out'
@@ -54,7 +54,7 @@ function compile_go_protobuf() {
         github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
       )
 
-      GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool "${grpc_gateway_proto_tools[@]}"
+      GO_TOOL_VENDOR=true install_go_tool "${grpc_gateway_proto_tools[@]}"
     fi
 
     # Install protoc-gen-lint from the internet instead of
@@ -63,7 +63,7 @@ function compile_go_protobuf() {
     #
     # only_if the script has an entry like: '--lint_out'
     if [[ "$(grep -w "\\-\\-lint_out" "$proto_script")" != "" ]]; then
-      install_go_tool github.com/ckaznocha/protoc-gen-lint
+      GO_TOOL_METHOD="get" install_go_tool github.com/ckaznocha/protoc-gen-lint
     fi
 
     eval "$proto_script";


### PR DESCRIPTION
Before we where only installing go tools from the vendor/ directory,
this PR is now adding the ability to install go tools NOT from a vendor/
dir.

As an example of the new usage: Install a number of go tools from your vendor/ directory
```
  local proto_go_tools=(
    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
    github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
    github.com/golang/protobuf/protoc-gen-go
  )
  GO_TOOL_METHOD="install" GO_TOOL_VENDOR=true install_go_tool "\${proto_go_tools[@]}"
```

Not from vendors dir:
```
  GO_TOOL_METHOD="install" install_go_tool "github.com/local/path/of/tool"
```

Signed-off-by: Salim Afiune <afiune@chef.io>