### PR TITLE
Fix go_build studio helper

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -188,10 +188,11 @@ function go_build() {
     fi
 
     if [[ $RUN_GO_DEP == true ]]; then
+      echo "=> Executing dep ensure"
       dep_ensure
-      echo "=> Executing Go build"
-      eval "$go_cmd $go_main"
     fi
+    echo "=> Executing Go build"
+    eval "$go_cmd $go_main"
   )
 }
 add_alias "go_build" "gb"


### PR DESCRIPTION
Even if we don't run `dep ensure` we still want to run `go build`, that is the main purpose of this function.