### PR TITLE
Adds colors and logging helpers to studio

### DIFF
--- a/dot-studio/habitat_overrides
+++ b/dot-studio/habitat_overrides
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright:: Copyright 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Defining a few helper functions that are only available when habitat builds a package
+# => https://www.habitat.sh/docs/reference/#plan-helper-functions
+#
+# This is very useful when we need to re-use scaffolding callbacks
+function pkg_path_for() {
+  hab pkg path "$1"
+}
+function build_line() {
+  echo -e "  $(blue hab-studio:) $1"
+}
+# Use `exit_with` only in very critical situations where you need to exit completely from the studio
+function exit_with() {
+  error "$1"
+  exit "$2"
+}

--- a/dot-studio/logging
+++ b/dot-studio/logging
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright:: Copyright 2018 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# ANSI Escape Codes:
+#
+# Just so you can be pretty in your messages :smile:
+#
+# Example:
+# => echo -e "I $(red love) $(blue chef) $(yellow friends)!"
+#
+NC='\033[0m' # No Color
+RED='\033[0;91m'
+GREEN='\033[0;92m'
+YELLOW='\033[0;93m'
+BLUE='\033[96m'
+
+function yellow(){
+  echo -e "${YELLOW}$1${NC}"
+}
+
+function red() {
+  echo -e "${RED}$1${NC}"
+}
+
+function green() {
+  echo -e "${GREEN}$1${NC}"
+}
+
+function blue() {
+  echo -e "${BLUE}$1${NC}"
+}
+# Wrapping build_line function to be called as `log_line` inside the studio
+# (prefered logging functions since it is just like inside a plan.sh)
+#
+# When used like:
+#
+# log_line "Doing something cool!"
+#
+# You will see the following output:
+#
+#     hag-studio: Doing something cool!
+#
+function log_line() {
+  build_line "$@"
+}
+
+function warn() {
+  echo -e "  $(yellow WARN:) $1"
+}
+
+function error() {
+  echo -e "  $(red ERROR:) $1"
+}


### PR DESCRIPTION
Alright, Friends!!! It is time to bring some color to the Studio!!

![tenor-46130349](https://user-images.githubusercontent.com/5712253/45901400-c746cd80-bdb0-11e8-83cc-1d611c731018.gif)

This PR adds a series of helper methods to log:

- `log_line` Logs a line, just like `build_line` from a habitat build plan.
- `warn` Logs a WARN message.
- `error` Logs an ERROR message.

After this PR gets merge I will work on updating our logs so that they look similar to this:

![screen shot 2018-09-21 at 3 27 50 pm](https://user-images.githubusercontent.com/5712253/45901981-f100f400-bdb2-11e8-855e-7eb239c061e9.png)

We also define a few helper functions that are only available when habitat builds a package, this is primarily to support scaffolding callbacks.

Signed-off-by: Salim Afiune <afiune@chef.io>