### PR TITLE
Install/upgrade Expeditor CLI as part of normal routine

### DIFF
--- a/buildkite-agent-hooks/update-utilities.sh
+++ b/buildkite-agent-hooks/update-utilities.sh
@@ -4,3 +4,7 @@ sudo ci-studio-common-util update
 
 echo "Updating 'hab'"
 sudo install-habitat
+
+echo "Updating 'expeditor' CLI"
+hab pkg install chef-es/expeditor-ruby
+hab pkg binlink --force chef-es/expeditor-ruby expeditor


### PR DESCRIPTION
Expeditor is a release engineering utility used by Chef. 

Signed-off-by: Tom Duffield <tom@chef.io>