### PR TITLE
Add check-rpm-signed and install-omnibus-product scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository houses some scripts / files that are used across various Chef pr
   * [Helpers](#helpers)
     + [`aws-configure`](#aws-configure)
     + [`ceval`](#ceval)
+    + [`check-rpm-signed`](#check-rpm-signed)
     + [`ci-studio-common-util`](#ci-studio-common-util)
     + [`citadel`](#citadel)
     + [`configure-github-account`](#configure-github-account)
@@ -24,6 +25,7 @@ This repository houses some scripts / files that are used across various Chef pr
     + [`hab-verify`](#hab-verify)
     + [`install-buildkite-agent`](#install-buildkite-agent)
     + [`install-habitat`](#install-habitat)
+    + [`install-omnibus-product`](#install-omnibus-product)
     + [`purge-habitat`](#purge-habitat)
 - [Habitat Studio](#habitat-studio)
   * [Installation](#installation-1)
@@ -147,6 +149,16 @@ GUIDANCE:
   2. If you're command requires double quotes, make sure to escape them.
 
         ceval "echo \"I'm a little tea pot\""
+```
+<!-- stdout -->
+
+#### `check-rpm-signed`
+
+<!-- stdout "./bin/check-rpm-signed --help" -->
+```
+Usage: check-rpm-signed RPM_FILE_NAME
+
+Verify that an rpm package has been signed.
 ```
 <!-- stdout -->
 
@@ -290,6 +302,23 @@ OPTIONS:
   -u USER       The user you want to run hab commands as. (default: user in '/var/opt/ci-studio-common/.hab-user' file, current user, or root)
   -v VERSION    Which version of Habitat you wish to install. (default: version in '.hab-version' file)
   -c CHANNEL    The channel from which you wish to install Habitat. (default: stable)
+```
+<!-- stdout -->
+
+#### `install-omnibus-product`
+
+<!-- stdout "./bin/install-omnibus-product" -->
+```
+Usage: ${0##*/} [-P PRODUCT] [-v VERSION] [-c CHANNEL] [-d DOWNLOAD_DIR] -h
+
+Download VERSION of PRODUCT from CHANNEL to DOWNLOAD_DIR and install it.
+
+OPTIONS:
+  -h               Show this message.
+  -P PRODUCT       The name of the product you wish to install. (required)
+  -v VERSION       Which version of the product you wish to install. (default: latest)
+  -c CHANNEL       The channel from which you wish to install the product. (default: stable)
+  -d DOWNLOAD_DIR  The directory to which you wish to download the product package. (default: PWD)
 ```
 <!-- stdout -->
 

--- a/bin/check-rpm-signed
+++ b/bin/check-rpm-signed
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright:: Copyright 2017 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# This script is based off of https://gist.github.com/cosimo/3760587
+
+set -eou pipefail
+
+function usage() {
+  cat <<DOC
+Usage: ${0##*/} RPM_FILE_NAME
+
+Verify that an rpm package has been signed.
+DOC
+}
+
+case "${1:-}" in
+  *.rpm)
+    package_file="$1"
+    ;;
+  "-h"|"--help")
+    usage
+    exit 0
+    ;;
+  "")
+    usage
+    exit 1
+    ;;
+  *)
+    echo "${0##*/}: invalid option '$1'"
+    echo "Try '${0##*/} --help' for more information."
+    exit 2
+esac
+
+if [[ ! -f "$package_file" ]]; then
+  echo "$package_file does not exist"
+  exit 1
+fi
+
+echo "--- Checking that $package_file has been signed."
+if [[ $(rpm -qpi "$package_file" 2>&1 | grep -c "Signature.*Key ID") -eq 1 ]]; then
+  echo "Verified $package_file has been signed."
+else
+  echo "Exiting with an error because $package_file has not been signed. Check your omnibus project config."
+  exit 1
+fi

--- a/bin/install-omnibus-product
+++ b/bin/install-omnibus-product
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Copyright:: Copyright 2017 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# This script is based off of https://gist.github.com/cosimo/3760587
+
+set -eou pipefail
+
+function usage() {
+  cat <<DOC
+Usage: ${0##*/} [-P PRODUCT] [-v VERSION] [-c CHANNEL] [-d DOWNLOAD_DIR] -h
+
+Download VERSION of PRODUCT from CHANNEL to DOWNLOAD_DIR and install it.
+
+OPTIONS:
+  -h               Show this message.
+  -P PRODUCT       The name of the product you wish to install. (required)
+  -v VERSION       Which version of the product you wish to install. (default: latest)
+  -c CHANNEL       The channel from which you wish to install the product. (default: stable)
+  -d DOWNLOAD_DIR  The directory to which you wish to download the product package. (default: PWD)
+DOC
+}
+
+channel="stable"
+download_dir="$(pwd)"
+product_name=""
+product_version="latest"
+
+while getopts ":c:d:P:v:h" opt
+do
+  case "$opt" in
+    c)
+      channel="$OPTARG"
+      ;;
+    d)
+      download_dir="$OPTARG"
+      ;;
+    P)
+      product_name="$OPTARG"
+      ;;
+    v)
+      product_version="$OPTARG"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      usage
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+# Exit if product_name is not set
+product_name=${product_name:?A product name must be specified}
+
+echo "--- Installing $channel $product_name $product_version"
+download_url="$(mixlib-install download --url --channel "$channel" "$product_name" --version "$product_version")"
+
+mixlib-install install-script | sudo bash -s -- -d "$download_dir" -l "$download_url" 2>&1
+
+package_file="${download_url##*/}"
+echo "${download_dir%/}/$package_file"


### PR DESCRIPTION
These scripts will help simplify omnibus project test scripts that will be used when tests are run in buildkite infrastructure instead of jenkins infrastructure.