### PR TITLE
Source the hook files rather than including them in the hook file

### DIFF
--- a/bin/install-buildkite-agent
+++ b/bin/install-buildkite-agent
@@ -101,7 +101,7 @@ function install_agent_hook() {
   fi
 
   header="echo \"--- executing hook: $hook\""
-  content=$(cat "$source_file")
+  content="source $source_file"
   footer="echo \"hook complete: $hook\""
   full_content="$header\\n$content\\n$footer"
 


### PR DESCRIPTION
This allows us to update the hooks without having to rebuild the AMI.