### PR TITLE
Temporarily removing the Expeditor CLI

### DIFF
--- a/buildkite-agent-hooks/update-utilities.sh
+++ b/buildkite-agent-hooks/update-utilities.sh
@@ -21,6 +21,7 @@ if habitat_supported_platform; then
   echo "Updating 'hab'"
   sudo install-habitat
 
-  echo "Updating 'expeditor' CLI"
-  hab pkg install chef-es/expeditor-ruby
+  # Temporarily removing the expeditor-cli
+  # echo "Updating 'expeditor' CLI"
+  # hab pkg install chef-es/expeditor-ruby
 fi


### PR DESCRIPTION
We aren't using it, and it appears the installation is causing issues.