### PR TITLE
Remove url encoding of "+" in version in install-omnibus-product

### DIFF
--- a/bin/install-omnibus-product
+++ b/bin/install-omnibus-product
@@ -74,7 +74,7 @@ product_name=${product_name:?A product name must be specified}
 
 echo "--- Installing $channel $product_name $product_version"
 # url encode product_version in case it includes '+' from an appended timestamp
-download_url="$(mixlib-install download --url --channel "$channel" "$product_name" --version "${product_version//+/%2B}")"
+download_url="$(mixlib-install download --url --channel "$channel" "$product_name" --version "$product_version")"
 
 mixlib-install install-script | sudo bash -s -- -d "$download_dir" -l "$download_url" 2>&1
 


### PR DESCRIPTION
mixlib-install should be responsible for encoding when necessary.

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>