### PR TITLE
Add matching parameter support for install-habitat

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,3 +1,6 @@
+project:
+  alias: ci-studio-common
+
 slack:
   notify_channel:
     - releng-notify

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -24,11 +24,11 @@ promote:
 merge_actions:
   - built_in:bump_version:
       ignore_labels:
-        - "Version: Skip Bump"
+        - "Expeditor: Skip Version Bump"
         - "Expeditor: Skip All"
   - built_in:update_changelog:
       ignore_labels:
-        - "Changelog: Skip Update"
+        - "Expeditor: Skip Changelog"
         - "Expeditor: Skip All"
   - bash:.expeditor/update_readme.sh:
       ignore_labels:
@@ -38,7 +38,7 @@ merge_actions:
         - bin/*
   - built_in:trigger_habitat_package_build:
       ignore_labels:
-        - "Habitat: Skip Build"
+        - "Expeditor: Skip Habitat"
         - "Expeditor: Skip All"
 
 subscriptions:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,34 +1,27 @@
 steps:
   - label: bats
     command: bats /ci-studio-common/tests
-    plugins:
-      - docker#v3.0.0:
-          image: chefes/buildkite
+    expeditor:
+      executor:
+        docker:
           workdir: /ci-studio-common
 
-  - label: in-studio
-    env:
-      STUDIO_OPTS: "-D"
-    agents:
-      queue: default-privileged
-    command:
-      - export PATH="\${BUILDKITE_BUILD_CHECKOUT_PATH}/bin:\$PATH"
-      - aws-configure chef-cd
-      - hab-verify in-studio ci_lint
-      - hab-verify in-studio ci_syntax
-
-  - label: habitat
-    agents:
-      queue: default-privileged
+  - label: ":habicat: x86_64-linux"
     command:
       - export PATH="/ci-studio-common/bin:\$PATH"
-      - aws-configure chef-cd
-      - hab-verify lint
-      - hab-verify syntax
-    plugins:
-      - docker#v3.0.0:
-          image: chefes/buildkite
+      - install-habitat
+    expeditor:
+      executor:
+        docker:
+          privileged: true
           workdir: /ci-studio-common
-          environment:
-            - CHEF_CD_AWS_ACCESS_KEY_ID
-            - CHEF_CD_AWS_SECRET_ACCESS_KEY
+
+  - label: ":habicat: x86_64-linux-kernel2"
+    command:
+      - export PATH="/ci-studio-common/bin:\$PATH"
+      - install-habitat -t x86_64-linux-kernel2
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          workdir: /ci-studio-common

--- a/bin/install-habitat
+++ b/bin/install-habitat
@@ -50,6 +50,7 @@ function handle_no_lock() {
 user="${USER:-root}"
 version=$(curl -sL https://raw.githubusercontent.com/chef/ci-studio-common/master/.hab-version)
 channel=stable
+target=x86_64-linux
 
 # If we've specified a certain user that should own Hab, use that
 hab_user_file="/var/opt/ci-studio-common/.hab-user"
@@ -57,8 +58,14 @@ if [[ -s $hab_user_file ]]; then
   user=$(cat $hab_user_file)
 fi
 
+# If we've specifed a certain target for Hab, use that
+hab_target_file="/var/opt/ci-studio-common/.hab-target"
+if [[ -s $hab_target_file ]]; then
+  target=$(cat $hab_target_file)
+fi
+
 # Parse the options
-while getopts ":c:v:u:h" opt; do
+while getopts ":c:v:u:t:h" opt; do
   case "${opt}" in
     c)
       channel="$OPTARG"
@@ -68,6 +75,9 @@ while getopts ":c:v:u:h" opt; do
       ;;
     u)
       user="$OPTARG"
+      ;;
+    t)
+      target="$OPTARG"
       ;;
     h)
       usage
@@ -98,17 +108,21 @@ fi
 
 echo "--- Installing Habitat"
 
-echo "Going to install habitat '$version' as '$user' user"
+echo "Going to install the '$target' build of habitat '$version' as '$user' user"
 tmp_user_file=$(mktemp hab-user.XXXXXX)
 echo "$user" > "$tmp_user_file"
 mv "$tmp_user_file" "$hab_user_file"
+
+tmp_target_file=$(mktemp hab-target.XXXXXX)
+echo "$target" > "$tmp_target_file"
+mv "$tmp_target_file" "$hab_target_file"
 
 echo "Creating /hab directory"
 mkdir -p /hab
 
 if [[ "$do_install_habitat" = "true" ]]; then
   echo "Running habitat curl|bash"
-  curl -sL https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash -s -- -v "$version" -c "$channel"
+  curl -sL https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash -s -- -v "$version" -c "$channel" -t "$target"
   echo "$version" > "$hab_version_file"
 else
   echo "Habitat is already up-to-date"

--- a/bin/install-habitat
+++ b/bin/install-habitat
@@ -31,6 +31,7 @@ OPTIONS:
   -u USER       The user you want to run hab commands as. (default: user in '/var/opt/ci-studio-common/.hab-user' file, current user, or root)
   -v VERSION    Which version of Habitat you wish to install. (default: version in '.hab-version' file)
   -c CHANNEL    The channel from which you wish to install Habitat. (default: stable)
+  -t TARGET     The kernel target for this installation. (default: target in '/var/opt/ci-studio-common/.hab-target' file or x86_64-linux)
 DOC
 }
 
@@ -107,6 +108,7 @@ if [[ -s $hab_version_file ]]; then
 fi
 
 echo "--- Installing Habitat"
+mkdir -p /var/opt/ci-studio-common
 
 echo "Going to install the '$target' build of habitat '$version' as '$user' user"
 tmp_user_file=$(mktemp hab-user.XXXXXX)
@@ -116,9 +118,6 @@ mv "$tmp_user_file" "$hab_user_file"
 tmp_target_file=$(mktemp hab-target.XXXXXX)
 echo "$target" > "$tmp_target_file"
 mv "$tmp_target_file" "$hab_target_file"
-
-echo "Creating /hab directory"
-mkdir -p /hab
 
 if [[ "$do_install_habitat" = "true" ]]; then
   echo "Running habitat curl|bash"


### PR DESCRIPTION
Fully match parameter support for install-habitat. Specifically, allow us to specify the install target. 
