### PR TITLE
Fix minor issues in Expeditor Hook

### DIFF
--- a/buildkite-agent-hooks/expeditor.sh
+++ b/buildkite-agent-hooks/expeditor.sh
@@ -34,10 +34,10 @@ if habitat_supported_platform; then
   ) 201>/tmp/hab-pkg-install-expeditor-cli.lock
 fi
 
-if [[ -n "$EXPEDITOR_ACCOUNTS" ]]; then
+if [[ -n "${EXPEDITOR_ACCOUNTS:-}" ]]; then
   hab pkg exec chef-es/expeditor-cli expeditor buildkite configure-job
 fi
 
-if [[ -n "$EXPEDITOR_SECRETS" ]]; then
+if [[ -n "${EXPEDITOR_SECRETS:-}" ]]; then
   . $(hab pkg path chef-es/expeditor-cli)/bin/load-secrets
 fi

--- a/buildkite-agent-hooks/expeditor.sh
+++ b/buildkite-agent-hooks/expeditor.sh
@@ -3,6 +3,8 @@
 
 set -eou pipefail
 
+export HAB_NONINTERACTIVE=true
+
 habitat_supported_platform() {
   local habitat_supported_archs_regex='.*x86_64|amd64.*'
   local platform="linux"


### PR DESCRIPTION
* Set `HAB_NONINTERACTIVE=true` to prevent log overflow due to interactive elements of downloading hab packages. 
* Modify bash logic to not panic when `EXPEDITOR_*` environment variables are missing. 

Signed-off-by: Tom Duffield <tom@chef.io>