### PR TITLE
Set HAB_NONINTERACTIVE and HAB_NOCOLORING

### DIFF
--- a/buildkite-agent-hooks/expeditor.sh
+++ b/buildkite-agent-hooks/expeditor.sh
@@ -4,6 +4,7 @@
 set -eou pipefail
 
 export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
 
 habitat_supported_platform() {
   local habitat_supported_archs_regex='.*x86_64|amd64.*'

--- a/buildkite-agent-hooks/update-utilities.sh
+++ b/buildkite-agent-hooks/update-utilities.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script has been deprecated in favor of the expeditor environment hook.
 
+export HAB_NONINTERACTIVE=true
+export HAB_NOCOLORING=true
+
 habitat_supported_platform() {
   local habitat_supported_archs_regex='.*x86_64|amd64.*'
   local platform="linux"


### PR DESCRIPTION
We had the former set in the new expeditor.sh hook but not in the
still-in-use update-utilities.sh script.

Signed-off-by: Steven Danna <steve@chef.io>
