### PR TITLE
Install gofmt when we install go.

### DIFF
--- a/dot-studio/golang
+++ b/dot-studio/golang
@@ -57,6 +57,7 @@ function setup_go_workspace() {
 
   # Install go & git
   install_if_missing core/go go
+  install_if_missing core/go gofmt
   install_if_missing core/git git
   log_line "$(green "Available scaffolding variables:")"
   log_line "  \$scaffolding_go_gopath        - $scaffolding_go_gopath"


### PR DESCRIPTION

## Description
Chef automate has some makefiles that assume gofmt is in the PATH, and I would assume `setup_go_workspace` would make all the golang things work.

## Related Issue
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
