### PR TITLE
Do not prefix output with '---'

### DIFF
--- a/bin/install-habitat
+++ b/bin/install-habitat
@@ -107,7 +107,7 @@ if [[ -s $hab_version_file ]]; then
   fi
 fi
 
-echo "--- Installing Habitat"
+echo "Installing Habitat"
 mkdir -p /var/opt/ci-studio-common
 
 echo "Going to install the '$target' build of habitat '$version' as '$user' user"


### PR DESCRIPTION
This can cause weird log grouping behavior in Buildkite, especially
when used in the `docker` Expeditor executor.

Signed-off-by: Tom Duffield <tom@chef.io>
