### PR TITLE
Add check-omnibus-package-signed utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository houses some scripts / files that are used across various Chef pr
   * [Helpers](#helpers)
     + [`aws-configure`](#aws-configure)
     + [`ceval`](#ceval)
+    + [`check-omnibus-package-signed`](#check-omnibus-package-signed)
     + [`check-rpm-signed`](#check-rpm-signed)
     + [`ci-studio-common-util`](#ci-studio-common-util)
     + [`citadel`](#citadel)
@@ -153,7 +154,19 @@ GUIDANCE:
 ```
 <!-- stdout -->
 
+#### `check-omnibus-package-signed`
+
+<!-- stdout "./bin/check-omnibus-package-signed --help" -->
+```
+Usage: check-omnibus-package-signed [DMG_FILE_NAME | RPM_FILE_NAME]
+
+Verify that an rpm is signed or that a dmg contains a signed package.
+```
+<!-- stdout -->
+
 #### `check-rpm-signed`
+
+**Deprecated in favor of check-omnibus-package-signed**
 
 <!-- stdout "./bin/check-rpm-signed --help" -->
 ```

--- a/bin/check-omnibus-package-signed
+++ b/bin/check-omnibus-package-signed
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright:: Copyright 2017 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# This script is based off of https://gist.github.com/cosimo/3760587
+
+set -eou pipefail
+
+function usage() {
+  cat <<DOC
+Usage: ${0##*/} [DMG_FILE_NAME | RPM_FILE_NAME]
+
+Verify that an rpm is signed or that a dmg contains a signed package.
+DOC
+}
+
+case "${1:-}" in
+  *.dmg | *.rpm)
+    package_file="$1"
+    ;;
+  "-h"|"--help")
+    usage
+    exit 0
+    ;;
+  "")
+    usage
+    exit 1
+    ;;
+  *)
+    echo "Skipping signed package verification. '$1' is not a dmg or rpm."
+    exit 0
+esac
+
+if [[ ! -f "$package_file" ]]; then
+  echo "$package_file does not exist"
+  exit 1
+fi
+
+case "$package_file" in
+  *.dmg)
+    echo "--- Checking that $package_file contains a signed package."
+    hdiutil detach "/Volumes/chef_software" >/dev/null 2>&1 || true
+    hdiutil attach "$package_file" -mountpoint "/Volumes/chef_software"
+    pkg_file="$(find "/Volumes/chef_software" -name "*.pkg")"
+    result=$(pkgutil --check-signature "$pkg_file" 2>&1 | grep -c "Status: signed")
+    hdiutil detach "/Volumes/chef_software"
+    if [[ $result -eq 1 ]]; then
+      echo "Verified $package_file contains a signed package."
+    else
+      echo "Exiting with an error because $package_file does not contain a signed package. Check your omnibus project config."
+      exit 1
+    fi
+    ;;
+  *.rpm)
+    echo "--- Checking that $package_file has been signed."
+    if [[ $(rpm -qpi "$package_file" 2>&1 | grep -c "Signature.*Key ID") -eq 1 ]]; then
+      echo "Verified $package_file has been signed."
+    else
+      echo "Exiting with an error because $package_file has not been signed. Check your omnibus project config."
+      exit 1
+    fi
+    ;;
+esac


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This utility makes it easy to verify that an
rpm has been signed or that a dmg contains a
signed package file.

This replaces functionality of the check-rpm-signed utility.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://github.com/chef/release-engineering/issues/569

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
