### PR TITLE
Use `sudo -E` when calling `hab pkg install`

### DIFF
--- a/buildkite-agent-hooks/expeditor.sh
+++ b/buildkite-agent-hooks/expeditor.sh
@@ -32,7 +32,7 @@ if habitat_supported_platform; then
     echo "Installing Expeditor CLI with exclusive lock (timeout 120s)..."
     flock --exclusive --wait 120 201
 
-    sudo hab pkg install --channel "${EXPEDITOR_CHANNEL:-stable}" chef-es/expeditor-cli
+    sudo -E hab pkg install --channel "${EXPEDITOR_CHANNEL:-stable}" chef-es/expeditor-cli
 
     if [[ -n "${EXPEDITOR_ACCOUNTS:-}" ]]; then
       hab pkg exec chef-es/expeditor-cli expeditor buildkite configure-job

--- a/buildkite-agent-hooks/update-utilities.sh
+++ b/buildkite-agent-hooks/update-utilities.sh
@@ -29,6 +29,6 @@ if habitat_supported_platform; then
   (
     echo "Installing Expeditor CLI with exclusive lock (timeout 120s)..."
     flock --exclusive --wait 120 201
-    sudo hab pkg install --channel "${EXPEDITOR_CHANNEL:-stable}" chef-es/expeditor-cli
+    sudo -E hab pkg install --channel "${EXPEDITOR_CHANNEL:-stable}" chef-es/expeditor-cli
   ) 201>/tmp/hab-pkg-install-expeditor-cli.lock
 fi


### PR DESCRIPTION
`sudo -E` preserves the callers environment. In this case, our
environment includes `HAB_NONINTERACTIVE` and `HAB_NOCOLORING` which
prevents hundreds of log lines in CI logs.

Signed-off-by: Steven Danna <steve@chef.io>