### PR TITLE
Mark subset of tooling as deprecated

### DIFF
--- a/bin/aws-configure
+++ b/bin/aws-configure
@@ -22,6 +22,8 @@ function usage() {
   cat <<DOC
 Usage: ${0##*/} [PROFILE]
 
+DEPRECATED: This utility has been deprecated and will be removed in the next major version.
+
 A non-interactive version of 'aws configure' that allows you to configure AWS CLI profiles.
 
 To add a new profile, you MUST specify following environment variables:

--- a/bin/ceval
+++ b/bin/ceval
@@ -22,6 +22,8 @@ function usage() {
   cat <<DOC
 Usage: ${0##*/} COMMAND
 
+DEPRECATED: This utility has been deprecated and will be removed in the next major version.
+
 Conditionally evaluate the given COMMAND.
 
     If the DEBUG environment variable is unset, ${0##*/} will evaluate the COMMAND using 'eval'.

--- a/bin/citadel
+++ b/bin/citadel
@@ -31,6 +31,8 @@ function usage() {
   cat <<DOC
 Usage: ${0##*/} FILE
 
+DEPRECATED: This utility has been deprecated and will be removed in the next major version.
+
 A Bash utility that prints the contents of the given FILE from the CITADEL_BUCKET in S3 to STDOUT.
 
 Requires that you have an AWS profile configured. To configure an AWS profile, you can use 'aws-configure [PROFILE]'.

--- a/bin/configure-github-account
+++ b/bin/configure-github-account
@@ -22,6 +22,8 @@ function usage() {
   cat <<DOC
 Usage: ${0##*/} ACCOUNT
 
+DEPRECATED: This utility has been deprecated and will be removed in the next major version.
+
 Configure GitHub credentials for ACCOUNT.
 
 Requires you have the following environment variables set:

--- a/bin/hab-origin
+++ b/bin/hab-origin
@@ -22,6 +22,8 @@ function usage() {
   cat <<DOC
 Usage: ${0##*/} SUBCOMMAND
 
+DEPRECATED: This utility has been deprecated and will be removed in the next major version.
+
 Helpers that extend functionality of the hab origin namespace.
 
 SUBCOMMANDS:

--- a/bin/hab-verify
+++ b/bin/hab-verify
@@ -22,6 +22,8 @@ function usage() {
   cat <<DOC
 Usage: ${0##*/} SUBCOMMAND
 
+DEPRECATED: This utility has been deprecated and will be removed in the next major version.
+
 Helpers that perform common verification steps inside Habitat.
 
 SUBCOMMANDS:


### PR DESCRIPTION
Signed-off-by: Tom Duffield <tom@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

These tools are no longer required due to new functionality with Buildkite+Expeditor. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
