### PR TITLE
Fix did-modify to return immediately on true

### DIFF
--- a/did-modify/cmd/root.go
+++ b/did-modify/cmd/root.go
@@ -57,6 +57,7 @@ func detectModifiedFiles(cmd *cobra.Command, args []string) {
 		for _, globPattern := range globs {
 			if glob.Glob(globPattern, fileStat.Name) {
 				fmt.Print("true")
+                                return
 			}
 		}
 	}


### PR DESCRIPTION
Without this return it falls-through to also writing 'false' to stdout.

Signed-off-by: James Stocks <jstocks@chef.io>