### PR TITLE
Cache GitHub token on disk to avoid spamming token creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	google.golang.org/appengine v1.6.1 // indirect
 	google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3 // indirect
 	google.golang.org/grpc v1.21.1 // indirect
+	gopkg.in/djherbis/times.v1 v1.2.0
 	gopkg.in/src-d/go-git.v4 v4.12.0
 	honnef.co/go/tools v0.0.0-20190614002413-cb51c254f01b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/djherbis/times.v1 v1.2.0 h1:UCvDKl1L/fmBygl2Y7hubXCnY7t4Yj46ZrBFNUipFbM=
+gopkg.in/djherbis/times.v1 v1.2.0/go.mod h1:AQlg6unIsrsCEdQYhTzERy542dz6SFdQFZFv6mUY0P8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.3.1 h1:SK5KegNXmKmqE342YYN2qPHEnUYeoMiXXl1poUlI+o4=

--- a/vault-util/cmd/print-git-credentials.go
+++ b/vault-util/cmd/print-git-credentials.go
@@ -2,19 +2,23 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
 
 	"github.com/chef/ci-studio-common/lib"
 	"github.com/chef/ci-studio-common/vault-util/internal/account"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"gopkg.in/djherbis/times.v1"
 )
 
 var (
 	gitCredentialCmd = &cobra.Command{
 		Use:   "print-git-credentials [APP]",
 		Short: "Utility that will print credentials for a GitHub App from Vault in git-credential-helper format.",
-		Run:   printCredentials,
+		RunE:  printCredentialsE,
 	}
 )
 
@@ -22,14 +26,58 @@ func init() {
 	rootCmd.AddCommand(gitCredentialCmd)
 }
 
-func printCredentials(cmd *cobra.Command, args []string) {
+func printCredentialsE(cmd *cobra.Command, args []string) error {
 	appName := viper.GetString("github.default_app")
-	if len(args) >= 1 {
+	if len(args) == 2 {
 		appName = args[0]
 	}
 
-	acct, err := account.NewGithubAccount(appName)
-	lib.Check(err)
+	filename := lib.SettingsPath(fmt.Sprintf("github_token_%s", appName))
 
-	fmt.Printf("protocol=https\nhost=github.com\nusername=x-access-token\npassword=%s\n", acct.Token)
+	var token string
+
+	times, err := times.Stat(filename)
+	if err != nil {
+		token, err = reloadTokenFromVault(filename, appName)
+		if err != nil {
+			return err
+		}
+	} else {
+		// The timeout is 1hr, but give ourselves some wiggle room
+		someMinutesAgo := time.Now().Add(time.Duration(-55) * time.Minute)
+
+		if times.ChangeTime().Before(someMinutesAgo) {
+			token, err = reloadTokenFromVault(filename, appName)
+			if err != nil {
+				return err
+			}
+		} else {
+			tokenRaw, err := ioutil.ReadFile(filename)
+			if err != nil {
+				token, err = reloadTokenFromVault(filename, appName)
+				if err != nil {
+					return err
+				}
+			} else {
+				token = strings.TrimSpace(string(tokenRaw))
+			}
+		}
+	}
+
+	fmt.Printf("username=x-access-token\npassword=%s", token)
+	return nil
+}
+
+func reloadTokenFromVault(filename string, appName string) (string, error) {
+	acct, err := account.NewGithubAccount(appName)
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(filename, []byte(acct.Token), 0600)
+	if err != nil {
+		return "", err
+	}
+
+	return acct.Token, nil
 }


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
The way this utility was previously designed, it would create a fresh
installation token on every git request, which could be more than 1 per
second. That would essentially create one token for every git request,
which is not what we want.

This design will create a token and save it to disk. We'll then read
the token from disk if it exists and is unexpired, otherwise we'll
create a fresh token.

We are writing the token to disk in plaintext, but it is a temporary
token. Given the current usage patterns, it's an acceptable trade off
at the moment. In the future, if we become more concerned, we can store
the token encrypted. However, we store AWS credentials in plaintext on
disk, so I think we'll be okay.

Signed-off-by: Tom Duffield <tom@chef.io>
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
