### PR TITLE
Fix update_hab_version.sh to use correct path

### DIFF
--- a/.expeditor/update_hab_version.sh
+++ b/.expeditor/update_hab_version.sh
@@ -12,7 +12,7 @@ fi
 branch="expeditor/upgrade-hab"
 git checkout -b "$branch"
 
-file-mod find-and-replace "globalHabValue.+" "globalHabValue = \"$EXPEDITOR_VERSION\"" install-habitat/cmd/root.go
+file-mod find-and-replace "globalHabValue.+" "globalHabValue = \"$EXPEDITOR_VERSION\"" cmd/install-habitat/commands/root.go
 
 git add .
 git commit --message "Update to habitat $EXPEDITOR_VERSION" --message "This pull request was triggered automatically via Expeditor when Habitat $EXPEDITOR_VERSION was promoted to stable." --message "This change falls under the obvious fix policy so no Developer Certificate of Origin (DCO) sign-off is required."

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - stylecheck
     - unparam
     - lll
+    - wsl
 
 issues:
   exclude-rules:


### PR DESCRIPTION
In the recent rewrite work, the path to the relevant file has changed.

Signed-off-by: Steven Danna <steve@chef.io>