### PR TITLE
Bump Habitat to 0.90.6

### DIFF
--- a/cmd/install-habitat/commands/root.go
+++ b/cmd/install-habitat/commands/root.go
@@ -33,7 +33,7 @@ var (
 	execCommand = exec.Command
 
 	// DO NOT MODIFY -- This value is automatically updated by Expeditor
-	globalHabValue = "0.83.0"
+	globalHabValue = "0.90.6"
 
 	rootCmd = &cobra.Command{
 		Use:   "install-habitat",


### PR DESCRIPTION
The Habitat build pipeline changes have broken the automation that is
in place for this.

Signed-off-by: Steven Danna <steve@chef.io>