### PR TITLE
Update tar to exclude tar from the tar itself since it would mess with the directory

### DIFF
--- a/.expeditor/create_release.sh
+++ b/.expeditor/create_release.sh
@@ -27,7 +27,7 @@ function download_artifacts {
       zip -j "${util_name}_${os}_${arch}.zip" "${file}"
       files+=("${util_name}_${os}_${arch}.zip")
     else
-      tar -czf "${file}_${os}_${arch}.tar.gz" -C "go-binaries/${os}/${arch}" .
+      tar -czf "${file}_${os}_${arch}.tar.gz" --exclude "${file}_${os}_${arch}.tar.gz" -C "go-binaries/${os}/${arch}" .
       files+=("${file}_${os}_${arch}.tar.gz")
     fi
   done

--- a/.expeditor/create_release.sh
+++ b/.expeditor/create_release.sh
@@ -27,7 +27,7 @@ function download_artifacts {
       zip -j "${util_name}_${os}_${arch}.zip" "${file}"
       files+=("${util_name}_${os}_${arch}.zip")
     else
-      tar -czf "${file}_${os}_${arch}.tar.gz" --exclude "${file}_${os}_${arch}.tar.gz" -C "go-binaries/${os}/${arch}" .
+      tar -czf "${file}_${os}_${arch}.tar.gz" -C "go-binaries/${os}/${arch}" "${file}"
       files+=("${file}_${os}_${arch}.tar.gz")
     fi
   done


### PR DESCRIPTION
Using `.` will mess with the contents of the tar and provide a `tar: .: file changed as we read it`. Using the file itself will hopefully avoid that error.

Signed-off-by: Nathaniel Kierpiec <nkierpiec@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
