### PR TITLE
CHEF-30377 - Create CONTRIBUTING.md file with inactive template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# This Project Has Been Archived and is Not Accepting Contributions
+
+Thank you for your interest in contributing to this project! However, it has reached the end of its lifecycle, and is no longer accepting contributions. If you are interested in contributing to other Chef projects, please see [Contributing to Progress Chef Projects](https://chef.github.io/chef-oss-practices/contributors/guide/).


### PR DESCRIPTION
This repo is being archived and is no longer accepting contributions.
Create CONTRIBUTING.md file with standard template indicating that the repo has been archived and is no longer accepting contributions.
This pull request creates CONTRIBUTING.md file with the standard template for the inactive projects.  As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025), when a repo is formally archived, we are replacing all the different contributing guides with a standard template that links to a message about archived repos.
